### PR TITLE
[QNX] Platform Entropy fix

### DIFF
--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -44,7 +44,7 @@
 #if !defined(MBEDTLS_NO_PLATFORM_ENTROPY)
 
 #if !defined(unix) && !defined(__unix__) && !defined(__unix) && \
-    !defined(__APPLE__) && !defined(_WIN32)
+    !defined(__APPLE__) && !defined(_WIN32) && !defined(__QNX__)
 #error "Platform entropy sources only work on Unix and Windows, see MBEDTLS_NO_PLATFORM_ENTROPY in config.h"
 #endif
 


### PR DESCRIPTION
We need a small fix for the upcoming QNX platfrom in mbedtls. 
The change matches the official mbedtls upstream.
https://github.com/ARMmbed/mbedtls/blob/development/library/entropy_poll.c